### PR TITLE
Replace fuse-bindings with fuse-native

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-const Fuse = require('fuse-bindings')
+const Fuse = require('fuse-native')
 const debug = require('debug')('ipfs-fuse:index')
 const IpfsApi = require('ipfs-http-client')
 const mkdirp = require('mkdirp')
@@ -47,7 +47,7 @@ exports.mount = (mountPath, opts, cb) => {
       })
     },
     mount: ['path', 'ipfs', (res, cb) => {
-      Fuse.mount(mountPath, createIpfsFuse(res.ipfs), opts.fuse, (err) => {
+      const fuse = new Fuse(mountPath, createIpfsFuse(res.ipfs), opts.fuse).mount((err) => {
         if (err) {
           err = explain(err, 'Failed to mount IPFS FUSE volume')
           debug(err)

--- a/ipfs-fuse/create.js
+++ b/ipfs-fuse/create.js
@@ -1,4 +1,4 @@
-const Fuse = require('fuse-bindings')
+const Fuse = require('fuse-native')
 const explain = require('explain-error')
 const debug = require('debug')('ipfs-fuse:create')
 

--- a/ipfs-fuse/ftruncate.js
+++ b/ipfs-fuse/ftruncate.js
@@ -1,4 +1,4 @@
-const Fuse = require('fuse-bindings')
+const Fuse = require('fuse-native')
 const explain = require('explain-error')
 const debug = require('debug')('ipfs-fuse:ftruncate')
 

--- a/ipfs-fuse/getattr.js
+++ b/ipfs-fuse/getattr.js
@@ -1,4 +1,4 @@
-const Fuse = require('fuse-bindings')
+const Fuse = require('fuse-native')
 const explain = require('explain-error')
 const debug = require('debug')('ipfs-fuse:getattr')
 

--- a/ipfs-fuse/mkdir.js
+++ b/ipfs-fuse/mkdir.js
@@ -1,4 +1,4 @@
-const Fuse = require('fuse-bindings')
+const Fuse = require('fuse-native')
 const explain = require('explain-error')
 const debug = require('debug')('ipfs-fuse:mkdir')
 

--- a/ipfs-fuse/mknod.js
+++ b/ipfs-fuse/mknod.js
@@ -1,4 +1,4 @@
-const Fuse = require('fuse-bindings')
+const Fuse = require('fuse-native')
 const explain = require('explain-error')
 const debug = require('debug')('ipfs-fuse:mknod')
 

--- a/ipfs-fuse/open.js
+++ b/ipfs-fuse/open.js
@@ -1,4 +1,4 @@
-// const Fuse = require('fuse-bindings')
+// const Fuse = require('fuse-native')
 const debug = require('debug')('ipfs-fuse:open')
 
 module.exports = (ipfs, fds) => {

--- a/ipfs-fuse/read.js
+++ b/ipfs-fuse/read.js
@@ -1,4 +1,4 @@
-const Fuse = require('fuse-bindings')
+const Fuse = require('fuse-native')
 const explain = require('explain-error')
 const debug = require('debug')('ipfs-fuse:read')
 

--- a/ipfs-fuse/readdir.js
+++ b/ipfs-fuse/readdir.js
@@ -1,4 +1,4 @@
-const Fuse = require('fuse-bindings')
+const Fuse = require('fuse-native')
 const explain = require('explain-error')
 const debug = require('debug')('ipfs-fuse:readdir')
 

--- a/ipfs-fuse/rename.js
+++ b/ipfs-fuse/rename.js
@@ -1,4 +1,4 @@
-const Fuse = require('fuse-bindings')
+const Fuse = require('fuse-native')
 const explain = require('explain-error')
 const debug = require('debug')('ipfs-fuse:rename')
 

--- a/ipfs-fuse/rmdir.js
+++ b/ipfs-fuse/rmdir.js
@@ -1,4 +1,4 @@
-const Fuse = require('fuse-bindings')
+const Fuse = require('fuse-native')
 const explain = require('explain-error')
 const debug = require('debug')('ipfs-fuse:rmdir')
 

--- a/ipfs-fuse/statfs.js
+++ b/ipfs-fuse/statfs.js
@@ -1,4 +1,4 @@
-const Fuse = require('fuse-bindings')
+const Fuse = require('fuse-native')
 const explain = require('explain-error')
 const debug = require('debug')('ipfs-fuse:statfs')
 

--- a/ipfs-fuse/unlink.js
+++ b/ipfs-fuse/unlink.js
@@ -1,4 +1,4 @@
-const Fuse = require('fuse-bindings')
+const Fuse = require('fuse-native')
 const explain = require('explain-error')
 const debug = require('debug')('ipfs-fuse:unlink')
 

--- a/ipfs-fuse/utimens.js
+++ b/ipfs-fuse/utimens.js
@@ -1,4 +1,4 @@
-const Fuse = require('fuse-bindings')
+const Fuse = require('fuse-native')
 const explain = require('explain-error')
 const debug = require('debug')('ipfs-fuse:utimens')
 

--- a/ipfs-fuse/write.js
+++ b/ipfs-fuse/write.js
@@ -1,4 +1,4 @@
-const Fuse = require('fuse-bindings')
+const Fuse = require('fuse-native')
 const explain = require('explain-error')
 const debug = require('debug')('ipfs-fuse:write')
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1019,15 +1019,48 @@
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
       "dev": true
     },
-    "fuse-bindings": {
-      "version": "2.11.2",
-      "resolved": "https://registry.npmjs.org/fuse-bindings/-/fuse-bindings-2.11.2.tgz",
-      "integrity": "sha512-53gc5h3VDYY9QmFu4tFU9NgKfR51AgKGhl7Uj1EX63RDU5kiBo2ooDvBiuawlS/iyEprUnzjlcDny1N/VhWNnA==",
+    "fuse-native": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/fuse-native/-/fuse-native-2.2.1.tgz",
+      "integrity": "sha512-WLpxO6Yfxe7KHybHqFUgtSHfhTsqZPF8XnerTc+tdyFy6Ruy35jFrYjfve6oX+ggQKVUzQAeSfJ+ac3vLvWyKA==",
       "requires": {
-        "nan": "^2.3.5",
-        "node-gyp-build": "^3.2.2",
-        "xtend": "^4.0.1"
+        "fuse-shared-library": "^1.0.2",
+        "nanoresource": "^1.3.0",
+        "napi-macros": "^2.0.0",
+        "node-gyp-build": "^4.2.0"
+      },
+      "dependencies": {
+        "node-gyp-build": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.2.1.tgz",
+          "integrity": "sha512-XyCKXsqZfLqHep1hhsMncoXuUNt/cXCjg1+8CLbu69V1TKuPiOeSGbL9n+k/ByKH8UT0p4rdIX8XkTRZV0i7Sw=="
+        }
       }
+    },
+    "fuse-shared-library": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/fuse-shared-library/-/fuse-shared-library-1.1.1.tgz",
+      "integrity": "sha512-EfgTo/eS1euZFUe7x8KqyA40hV4DwP7kqp1VNZApu2nlPnJv8SanraBE3VXyX7ff41sxw7M0oWY7re3G3wnZVA==",
+      "requires": {
+        "fuse-shared-library-darwin": "^1.0.3",
+        "fuse-shared-library-linux": "^1.0.1",
+        "fuse-shared-library-linux-arm": "^1.0.0"
+      }
+    },
+    "fuse-shared-library-darwin": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/fuse-shared-library-darwin/-/fuse-shared-library-darwin-1.0.3.tgz",
+      "integrity": "sha512-CrQaTriJeFKns/vEK4rFpjdlM3HrDJwD+UINGPc2ArYq57+6EF/R36puQ4BUV/Uyn79Oxu356Iogtq3VqhKeJg=="
+    },
+    "fuse-shared-library-linux": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/fuse-shared-library-linux/-/fuse-shared-library-linux-1.0.1.tgz",
+      "integrity": "sha512-07MQRSobrBKwW4D7oKm0gM2TwgvZWb+gC08JdiYDG4KBTncxk9ssqEDiDMKll8hpseZufsY2w1yc/feOu2DPmQ=="
+    },
+    "fuse-shared-library-linux-arm": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fuse-shared-library-linux-arm/-/fuse-shared-library-linux-arm-1.0.0.tgz",
+      "integrity": "sha512-Dj4ssxo1/MKGvOsVWRblSRu+o5F5OJTrVPDkjSyGDU2yKvVnIzQSwy1deiWA0qCcS/Q8iJMlZaCpCcZWSwvoug=="
     },
     "get-stdin": {
       "version": "6.0.0",
@@ -1699,6 +1732,26 @@
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.12.1.tgz",
       "integrity": "sha512-JY7V6lRkStKcKTvHO5NVSQRv+RV+FIL5pvDoLiAtSL9pKlC5x9PKQcZDsq7m4FO4d57mkhC6Z+QhAh3Jdk5JFw=="
     },
+    "nanoresource": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/nanoresource/-/nanoresource-1.3.0.tgz",
+      "integrity": "sha512-OI5dswqipmlYfyL3k/YMm7mbERlh4Bd1KuKdMHpeoVD1iVxqxaTMKleB4qaA2mbQZ6/zMNSxCXv9M9P/YbqTuQ==",
+      "requires": {
+        "inherits": "^2.0.4"
+      },
+      "dependencies": {
+        "inherits": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+          "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+        }
+      }
+    },
+    "napi-macros": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-macros/-/napi-macros-2.0.0.tgz",
+      "integrity": "sha512-A0xLykHtARfueITVDernsAWdtIMbOJgKgcluwENp3AlsKN/PloyO10HtmoqnFAQAcxPkgZN7wdfPfEd0zNGxbg=="
+    },
     "natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -1751,11 +1804,6 @@
       "version": "0.7.6",
       "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.7.6.tgz",
       "integrity": "sha512-sol30LUpz1jQFBjOKwbjxijiE3b6pjd74YwfD0fJOKPjF+fONKb2Yg8rYgS6+bK6VDl+/wfr4IYpC7jDzLUIfw=="
-    },
-    "node-gyp-build": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-3.8.0.tgz",
-      "integrity": "sha512-bYbpIHyRqZ7sVWXxGpz8QIRug5JZc/hzZH4GbdT9HTZi6WmKCZ8GLvP8OZ9TTiIBvwPFKgtGrlWQSXDAvYdsPw=="
     },
     "nodeify": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "async": "^2.6.2",
     "debug": "^4.1.1",
     "explain-error": "^1.0.4",
-    "fuse-bindings": "^2.11.2",
+    "fuse-native": "^2.2.1",
     "ipfs-http-client": "^29.1.1",
     "mkdirp": "^0.5.1"
   },


### PR DESCRIPTION
I've been having issues installing this with the dependency `node-gyp`. Replacing `fuse-bindings` with its successor (https://github.com/fuse-friends/fuse-native) fixed the issues.

`fuse-native` uses a newer version of `node-gyp` which may have something to do with the fix. It also adds multithreading support, which may help with https://github.com/tableflip/ipfs-fuse/issues/5